### PR TITLE
Backend: Add deleteMultiple

### DIFF
--- a/.travisphpconfig.ini
+++ b/.travisphpconfig.ini
@@ -1,1 +1,2 @@
 extension="memcache.so"
+extension="memcached.so"

--- a/benchmarks/MatryoshkaBenchmark.php
+++ b/benchmarks/MatryoshkaBenchmark.php
@@ -228,6 +228,7 @@ class MatryoshkaBenchmark {
       $memcached = new Memcached();
       $memcached->addServer('localhost', 11211);
       $memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+      $memcached->setOption(Memcached::OPT_TCP_NODELAY, true);
       return $memcached;
    }
 

--- a/benchmarks/MatryoshkaBenchmark.php
+++ b/benchmarks/MatryoshkaBenchmark.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(E_ALL);
+
 require_once __DIR__ . '/../library/iFixit/Matryoshka.php';
 
 use iFixit\Matryoshka;
@@ -222,6 +224,13 @@ class MatryoshkaBenchmark {
       return $memcache;
    }
 
+   private static function getMemcached() {
+      $memcached = new Memcached();
+      $memcached->addServer('localhost', 11211);
+      $memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+      return $memcached;
+   }
+
    private static function getDisabled(Matryoshka\Backend $backend) {
       $disabled = new Matryoshka\Enable($backend);
       $disabled->getsEnabled = false;
@@ -276,6 +285,12 @@ class MatryoshkaBenchmark {
          );
          $allBackends['Memcache'] = Matryoshka\Memcache::create(
             self::getMemcache()
+         );
+      }
+
+      if (Matryoshka\Memcached::isAvailable()) {
+         $allBackends['Memcached'] = Matryoshka\Memcached::create(
+            self::getMemcached()
          );
       }
 

--- a/benchmarks/MatryoshkaBenchmark.php
+++ b/benchmarks/MatryoshkaBenchmark.php
@@ -134,7 +134,7 @@ class MatryoshkaBenchmark {
       $benchmarkRegex = $options['benchmark'];
       $backendRegex = $options['backend'];
 
-      $allResults = [];
+      $results = [];
       $benchmarkMethods = self::getBenchmarkMethods($benchmarkRegex);
 
       foreach ($benchmarkMethods as $method) {

--- a/library/iFixit/Matryoshka/Backend.php
+++ b/library/iFixit/Matryoshka/Backend.php
@@ -26,6 +26,15 @@ abstract class Backend {
    public abstract function set($key, $value, $expiration = 0);
 
    /**
+    * Sets multiple key/value pairs with the given expiration.
+    *
+    * @param $values Array of [key => value] to set.
+    *
+    * @return True if all values set successfully, false otherwise.
+    */
+   public abstract function setMultiple(array $values, $expiration = 0);
+
+   /**
     * Same as set except it does nothing if the key already exists.
     *
     * @return true on success, false if the key exists or the operation fails
@@ -156,22 +165,5 @@ abstract class Backend {
       }
 
       return $found;
-   }
-
-   /**
-    * Sets multiple key/value pairs with the given expiration.
-    *
-    * @param $values Array of [key => value] to set.
-    *
-    * @return True if all values set successfully, false otherwise.
-    */
-   public function setMultiple(array $values, $expiration = 0) {
-      $success = true;
-
-      foreach ($values as $key => $value) {
-         $success = $this->set($key, $value, $expiration) && $success;
-      }
-
-      return $success;
    }
 }

--- a/library/iFixit/Matryoshka/Backend.php
+++ b/library/iFixit/Matryoshka/Backend.php
@@ -95,6 +95,13 @@ abstract class Backend {
    public abstract function delete($key);
 
    /**
+    * Deletes multiple keys.
+    *
+    * @return true on success, false on failure
+    */
+   public abstract function deleteMultiple(array $keys);
+
+   /**
     * Wrapper around get and set that uses the provided callback to retrieve
     * and populate the cache if the key is not found in the cache. If
     * $callback returns Backend::NULL, the corresponding set() call won't

--- a/library/iFixit/Matryoshka/BackendWrap.php
+++ b/library/iFixit/Matryoshka/BackendWrap.php
@@ -49,4 +49,8 @@ abstract class BackendWrap extends Backend {
    public function delete($key) {
       return $this->backend->delete($key);
    }
+
+   public function deleteMultiple(array $keys) {
+      return $this->backend->deleteMultiple($keys);
+   }
 }

--- a/library/iFixit/Matryoshka/Enable.php
+++ b/library/iFixit/Matryoshka/Enable.php
@@ -88,4 +88,12 @@ class Enable extends Backend {
          return false;
       }
    }
+
+   public function deleteMultiple(array $keys) {
+      if ($this->deletesEnabled) {
+         return $this->backend->deleteMultiple($keys);
+      } else {
+         return false;
+      }
+   }
 }

--- a/library/iFixit/Matryoshka/Ephemeral.php
+++ b/library/iFixit/Matryoshka/Ephemeral.php
@@ -89,4 +89,18 @@ class Ephemeral extends Backend {
          return false;
       }
    }
+
+   public function deleteMultiple(array $keys) {
+      $success = true;
+
+      foreach ($keys as $key) {
+         if (array_key_exists($key, $this->cache)) {
+            unset($this->cache[$key]);
+         } else {
+            $success = false;
+         }
+      }
+
+      return $success;
+   }
 }

--- a/library/iFixit/Matryoshka/Hierarchy.php
+++ b/library/iFixit/Matryoshka/Hierarchy.php
@@ -138,4 +138,13 @@ class Hierarchy extends Backend {
 
       return $success;
    }
+
+   public function deleteMultiple(array $keys) {
+      $success = true;
+      foreach ($this->backends as $backend) {
+         $success = $backend->deleteMultiple($keys) && $success;
+      }
+
+      return $success;
+   }
 }

--- a/library/iFixit/Matryoshka/KeyChange.php
+++ b/library/iFixit/Matryoshka/KeyChange.php
@@ -70,4 +70,11 @@ abstract class KeyChange extends BackendWrap {
    public function delete($key) {
       return $this->backend->delete($this->changeKey($key));
    }
+
+   public function deleteMultiple(array $keys) {
+      // changeKeys works on [key => id, ...] rather than [key, ...] so we
+      // have to flip it and flip it back.
+      $changedKeys = array_flip($this->changeKeys(array_flip($keys)));
+      return $this->backend->deleteMultiple($changedKeys);
+   }
 }

--- a/library/iFixit/Matryoshka/Local.php
+++ b/library/iFixit/Matryoshka/Local.php
@@ -118,6 +118,16 @@ class Local extends Backend {
       return $success;
    }
 
+   public function deleteMultiple(array $keys) {
+      $success = $this->backend->deleteMultiple($keys);
+
+      foreach ($keys as $key) {
+         unset($this->cache[$key]);
+      }
+
+      return $success;
+   }
+
    public function setMultiple(array $values, $expiration = 0) {
       $success = $this->backend->setMultiple($values, $expiration);
 

--- a/library/iFixit/Matryoshka/Memcache.php
+++ b/library/iFixit/Matryoshka/Memcache.php
@@ -31,6 +31,16 @@ class Memcache extends Backend {
       return $this->memcache->set($key, $value, self::FLAGS, $expiration);
    }
 
+   public function setMultiple(array $values, $expiration = 0) {
+      $success = true;
+
+      foreach ($values as $key => $value) {
+         $success = $this->set($key, $value, $expiration) && $success;
+      }
+
+      return $success;
+   }
+
    public function add($key, $value, $expiration = 0) {
       return $this->memcache->add($key, $value, self::FLAGS, $expiration);
    }

--- a/library/iFixit/Matryoshka/Memcache.php
+++ b/library/iFixit/Matryoshka/Memcache.php
@@ -20,7 +20,7 @@ class Memcache extends Backend {
     * truncated.
     */
    public static function create(\Memcache $memcache) {
-      return new KeyShorten(new \iFixit\Matryoshka\Memcache($memcache), self::MAX_KEY_LENGTH);
+      return new KeyShorten(new self($memcache), self::MAX_KEY_LENGTH);
    }
 
    private function __construct(\Memcache $memcache) {

--- a/library/iFixit/Matryoshka/Memcache.php
+++ b/library/iFixit/Matryoshka/Memcache.php
@@ -111,4 +111,14 @@ class Memcache extends Backend {
    public function delete($key) {
       return $this->memcache->delete($key);
    }
+
+   public function deleteMultiple(array $keys) {
+      $success = true;
+
+      foreach ($keys as $key) {
+         $success = $this->memcache->delete($key) && $success;
+      }
+
+      return $success;
+   }
 }

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace iFixit\Matryoshka;
+
+use iFixit\Matryoshka;
+
+class Memcached extends Backend {
+   const MAX_KEY_LENGTH = 250;
+   private $memcached;
+
+   public static function isAvailable() {
+      return class_exists('\Memcached', false);
+   }
+
+   /**
+    * Factory method. This forces Memcached to always be wrapped in a
+    * KeyShorten to fix keys that are too long and would otherwise get
+    * truncated.
+    */
+   public static function create(\Memcached $memcached) {
+      return new KeyShorten(new self($memcached), self::MAX_KEY_LENGTH);
+   }
+
+   private function __construct(\Memcached $memcached) {
+      $this->memcached = $memcached;
+   }
+
+   public function set($key, $value, $expiration = 0) {
+      return $this->memcached->set($key, $value, $expiration);
+   }
+
+   public function setMultiple(array $values, $expiration = 0) {
+      return $this->memcached->setMulti($values, $expiration);
+   }
+
+   public function add($key, $value, $expiration = 0) {
+      return $this->memcached->add($key, $value, $expiration);
+   }
+
+   public function increment($key, $amount = 1, $expiration = 0) {
+      // Memcache doesn't support negative amounts for decrement or increment
+      // so send it to decrement to handle it.
+      if ($amount < 0) {
+         return $this->decrement($key, -$amount, $expiration);
+      }
+
+      return $this->memcached->increment($key, $amount, /* initial */ $amount,
+       $expiration);
+   }
+
+   public function decrement($key, $amount = 1, $expiration = 0) {
+      // Memcached doesn't support negative amounts for decrement or increment
+      // so send it to increment to handle it.
+      if ($amount < 0) {
+         return $this->increment($key, -$amount, $expiration);
+      }
+
+      return $this->memcached->decrement($key, $amount, /* initial */ $amount,
+       $expiration);
+   }
+
+   public function get($key) {
+      $value = $this->memcached->get($key);
+
+      return $value === false ? self::MISS : $value;
+   }
+
+   public function getMultiple(array $keys) {
+      if (empty($keys)) {
+         return [[],[]];
+      }
+
+      /**
+       * \Memcached::GET_PRESERVE_ORDER makes it so all keys are returned in
+       * the order that they were requested with null indicating a miss which
+       * is exactly what is needed for the found array.
+       */
+      $cas_tokens = null;
+      $found = $this->memcached->getMulti(array_keys($keys), $cas_tokens,
+       \Memcached::GET_PRESERVE_ORDER);
+
+      $missed = [];
+      foreach ($keys as $key => $id) {
+         if ($found[$key] === self::MISS) {
+            $missed[$key] = $id;
+         }
+      }
+
+      return [$found, $missed];
+   }
+
+   public function delete($key) {
+      return $this->memcached->delete($key);
+   }
+}

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -94,6 +94,17 @@ class Memcached extends Backend {
    }
 
    public function deleteMultiple(array $keys) {
+      // Some environments (HHVM) don't implement deleteMulti so we need to
+      // roll it ourselves.
+      if (!method_exists($this->memcached, 'deleteMulti')) {
+         $success = true;
+         foreach ($keys as $key) {
+            $success = $this->memcached->delete($key) && $success;
+         }
+
+         return $success;
+      }
+
       $results = $this->memcached->deleteMulti($keys);
 
       foreach ($results as $key => $success) {

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -92,4 +92,16 @@ class Memcached extends Backend {
    public function delete($key) {
       return $this->memcached->delete($key);
    }
+
+   public function deleteMultiple(array $keys) {
+      $results = $this->memcached->deleteMulti($keys);
+
+      foreach ($results as $key => $success) {
+         if ($success !== true) {
+            return false;
+         }
+      }
+
+      return true;
+   }
 }

--- a/library/iFixit/Matryoshka/Stats.php
+++ b/library/iFixit/Matryoshka/Stats.php
@@ -33,7 +33,10 @@ class Stats extends Backend {
          'getMultiple_hit_count' => 0,
          'getMultiple_time' => 0,
          'delete_count' => 0,
-         'delete_time' => 0
+         'delete_time' => 0,
+         'deleteMultiple_count' => 0,
+         'deleteMultiple_key_count' => 0,
+         'deleteMultiple_time' => 0,
       ];
    }
 
@@ -136,5 +139,17 @@ class Stats extends Backend {
       $this->stats['delete_time'] += $end - $start;
 
       return $value;
+   }
+
+   public function deleteMultiple(array $keys) {
+      $start = microtime(true);
+      $success = $this->backend->deleteMultiple($keys);
+      $end = microtime(true);
+
+      $this->stats['deleteMultiple_count']++;
+      $this->stats['deleteMultiple_key_count'] += count($keys);
+      $this->stats['deleteMultiple_time'] += $end - $start;
+
+      return $success;
    }
 }

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -75,6 +75,30 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $this->assertEmpty($missed);
    }
 
+   public function testdeleteMultiple() {
+      $backend = $this->getBackend();
+
+      list($key1, $value1) = $this->getRandomKeyValue();
+      list($key2, $value2) = $this->getRandomKeyValue();
+      list($key3, $value3) = $this->getRandomKeyValue();
+      list($key4, $value4) = $this->getRandomKeyValue();
+
+      $this->assertTrue($backend->set($key1, $value1));
+      $this->assertTrue($backend->set($key2, $value2));
+      $this->assertTrue($backend->set($key3, $value3));
+      $this->assertTrue($backend->set($key4, $value4));
+
+      $this->assertTrue($backend->deleteMultiple([$key1, $key2]));
+      $this->assertNull($backend->get($key1));
+      $this->assertNull($backend->get($key2));
+      $this->assertFalse($backend->deleteMultiple([$key1, $key3]));
+      $this->assertFalse($backend->deleteMultiple([$key1, $key2, $key3, $key4]));
+      $this->assertNull($backend->get($key1));
+      $this->assertNull($backend->get($key2));
+      $this->assertNull($backend->get($key3));
+      $this->assertNull($backend->get($key4));
+   }
+
    public function testadd() {
       $backend = $this->getBackend();
       list($key1, $value1) = $this->getRandomKeyValue();

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -107,7 +107,8 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       }
 
       $realValue = $backend->get($key1);
-      if (get_called_class() === 'MemcacheTest') {
+      if (get_called_class() === 'MemcacheTest'
+       || get_called_class() === 'MemcachedTest') {
          // HHVM's memcache get returns a string rather than an integer.
          $realValue = (int)$realValue;
       }
@@ -119,7 +120,8 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       // TODO: Memcache has some strange behavior with these values that
       // doesn't appear to match the docs. It might have to do with
       // compression.
-      if (get_called_class() !== 'MemcacheTest') {
+      if (get_called_class() !== 'MemcacheTest'
+       && get_called_class() !== 'MemcachedTest') {
          $invalidValues = [
             'string',
             ['array'],
@@ -142,7 +144,8 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
 
       // TODO: Memcache values cannot be decremented below 0 so we must
       // start it out higher.
-      if (get_called_class() === 'MemcacheTest') {
+      if (get_called_class() === 'MemcacheTest'
+       || get_called_class() === 'MemcachedTest') {
          $currentValue = 400;
          $backend->set($key1, $currentValue);
       } else {
@@ -155,7 +158,8 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       }
 
       $realValue = $backend->get($key1);
-      if (get_called_class() === 'MemcacheTest') {
+      if (get_called_class() === 'MemcacheTest'
+       || get_called_class() === 'MemcachedTest') {
          // HHVM's memcache get returns a string rather than an integer.
          $realValue = (int)$realValue;
       }
@@ -165,7 +169,8 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
 
       // TODO: Memcache has some strange behavior with these values that
       // doesn't appear to match the docs.
-      if (get_called_class() !== 'MemcacheTest') {
+      if (get_called_class() !== 'MemcacheTest'
+       && get_called_class() !== 'MemcachedTest') {
          $this->assertSame(-7, $backend->decrement($key1, 7));
 
          $invalidValues = [
@@ -374,7 +379,7 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $validChars = [
          '`', '~', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '_',
          '+', '=', '|', '\\', '[', '{', ']', '}', '<', ',', '>', '.', '?', '/',
-         '☃', ' ', "\n", "\r"
+         '☃', "\n", "\r"
       ];
 
       foreach ($validChars as $char) {

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -26,8 +26,8 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $this->assertSame($value1, $backend->get($key1));
       $this->assertTrue($backend->set($key1, $value1));
       $this->assertTrue($backend->delete($key1));
-      $this->assertFalse($backend->delete($key1));
       $this->assertNull($backend->get($key1));
+      $this->assertFalse($backend->delete($key1));
 
       $this->assertTrue($backend->set($key2, $value2));
       $this->assertTrue($backend->set($key3, $value3));

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -115,6 +115,7 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $this->assertSame($currentValue, $realValue);
 
       $this->assertTrue($backend->delete($key1));
+      $this->assertNull($backend->get($key1));
       $this->assertSame(7, $backend->increment($key1, 7));
 
       // TODO: Memcache has some strange behavior with these values that

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -199,8 +199,6 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $this->assertTrue($backend->set($key, $initialValue));
 
       $this->assertSame($initialValue - 1, $backend->increment($key, -1));
-      $this->assertEquals($initialValue - 1, $backend->get($key));
-
       $this->assertSame($initialValue, $backend->decrement($key, -1));
       $this->assertEquals($initialValue, $backend->get($key));
    }

--- a/tests/MemcachedTest.php
+++ b/tests/MemcachedTest.php
@@ -17,6 +17,7 @@ class MemcachedTest extends AbstractBackendTest {
       $memcached = new Memcached();
       $memcached->addServer('localhost', 11211);
       $memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+      $memcached->setOption(Memcached::OPT_TCP_NODELAY, true);
 
       return Matryoshka\Memcached::create($memcached);
    }

--- a/tests/MemcachedTest.php
+++ b/tests/MemcachedTest.php
@@ -4,9 +4,9 @@ require_once 'AbstractBackendTest.php';
 
 use iFixit\Matryoshka;
 
-class MemcacheTest extends AbstractBackendTest {
+class MemcachedTest extends AbstractBackendTest {
    protected function setUp() {
-      if (!Matryoshka\Memcache::isAvailable()) {
+      if (!Matryoshka\Memcached::isAvailable()) {
          $this->markTestSkipped('Backend not available!');
       }
 
@@ -14,10 +14,14 @@ class MemcacheTest extends AbstractBackendTest {
    }
 
    protected function getBackend() {
-      return Matryoshka\Memcache::create($this->getMemcache());
+      $memcached = new Memcached();
+      $memcached->addServer('localhost', 11211);
+      $memcached->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+
+      return Matryoshka\Memcached::create($memcached);
    }
 
-   public function testMemcache() {
+   public function testMemcached() {
       $backend = $this->getBackend();
       list($key, $value) = $this->getRandomKeyValue();
       $this->assertTrue($backend->set($key, $value, 1));

--- a/tests/StatsTest.php
+++ b/tests/StatsTest.php
@@ -30,12 +30,15 @@ class StatsTest extends AbstractBackendTest {
       $backend->get($key);
       $backend->getMultiple([$key => '', $key2 => '']);
       $backend->delete($key);
+      $backend->deleteMultiple([$key, $key2]);
 
       $end = microtime(true);
       $maxTime = $end - $start;
 
       foreach ($backend->getStats() as $stat => $value) {
-         if ($stat == 'getMultiple_key_count' || $stat == 'setMultiple_key_count') {
+         if ($stat == 'getMultiple_key_count' ||
+             $stat == 'setMultiple_key_count' ||
+             $stat == 'deleteMultiple_key_count') {
             $this->assertSame(2, $value, $stat);
          } else if (strpos($stat, '_count') !== false) {
             $this->assertSame(1, $value, $stat);


### PR DESCRIPTION
This adds `deleteMultiple` so you can easily delete multiple keys at
once rather than iterating over `delete`. This is particularly
beneficial for `Memcached` because it can take advantage of its
`deleteMulti` method. Also, this results in one traversal of the cache
stack rather than one traversal per cache key to delete.

Depends on #9.