### PR TITLE
Tests: add key char validity checking

### DIFF
--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -377,10 +377,11 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
          '☃', ' ', "\n", "\r"
       ];
 
+      list($baseKey, $value) = $this->getRandomKeyValue();
       foreach ($validChars as $char) {
-         list($key, $value) = $this->getRandomKeyValue();
-         $key .= $char;
+         $key = $baseKey . $char;
 
+         $this->assertSame(null, $backend->get($key), "Value already exists for key with ascii char (" . ord($char) . ") $char.");
          $this->assertTrue($backend->set($key, $value));
          $this->assertSame($value, $backend->get($key));
       }

--- a/tests/MemcacheTest.php
+++ b/tests/MemcacheTest.php
@@ -26,4 +26,12 @@ class MemcacheTest extends AbstractBackendTest {
 
       $this->assertNull($backend->get($key));
    }
+
+   /**
+    * Memcache turns whitespace in keys into underscores, so we have to
+    * exempt both chars from key equivalence tests.
+    */
+   protected function isCharExemptFromKeyEquivalence($char) {
+      return $char === '_' || preg_match("/\s/", $char);
+   }
 }


### PR DESCRIPTION
Assert all chars work as keys and only certain known ones are
considered equivalent.

Also, add exemptions for the chars that memcache same-ifies.