### PR TITLE
Backends: add APCu backend and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
 services: memcached
 before_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travisphpconfig.ini ; fi;'
+  - pecl install -f apcu-4.0.10
 script:
   - phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ php:
   - hhvm
 services: memcached
 before_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travisphpconfig.ini ; fi;'
-  - pecl install -f apcu-4.0.10
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travisphpconfig.ini ; pecl install -f apcu-4.0.10; fi;'
 script:
   - phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - hhvm
 services: memcached
 before_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travisphpconfig.ini ; pecl install -f apcu-4.0.10; fi;'
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-4.0.10; fi;'
 script:
   - phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/.travisphpconfig.ini
+++ b/.travisphpconfig.ini
@@ -1,2 +1,4 @@
 extension="memcache.so"
 extension="memcached.so"
+extension="apcu.so"
+apc.enable_cli=1

--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ $cache = Matryoshka\Memcache::create($memcache);
 $value = $cache->get('key');
 ```
 
+### APCu
+
+Caches values in a shared memory segment (available to all processes under
+a webserver) using the [APCu php extension].
+
+```php
+$cache = new Matryoshka\APCu();
+$cache->set('key', 'value');
+$value = $cache->get('key');
+```
+
 ### Ephemeral
 
 Caches values in a local memory array that lasts the duration of the PHP process.
@@ -260,3 +271,5 @@ $values = $cache->getAndSetMultiple($keys, function($missing) {
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
+
+[APCu php extension]: http://php.net/manual/en/book.apcu.php

--- a/benchmarks/MatryoshkaBenchmark.php
+++ b/benchmarks/MatryoshkaBenchmark.php
@@ -295,6 +295,10 @@ class MatryoshkaBenchmark {
          );
       }
 
+      if (Matryoshka\APCu::isAvailable()) {
+         $allBackends['APCu'] = new Matryoshka\APCu();
+      }
+
       if ($regex !== null) {
          foreach ($allBackends as $type => $backend) {
             if (!preg_match("/$regex/i", $type)) {

--- a/library/iFixit/Matryoshka/APCu.php
+++ b/library/iFixit/Matryoshka/APCu.php
@@ -56,6 +56,9 @@ class APCu extends Backend {
       $missed = [];
       foreach ($keys as $key => $id) {
          $value = array_key_exists($key, $hits) ? $hits[$key] : self::MISS;
+         // Abstract class function docs say $found[] should contain all keys
+         // with null values for the misses, so we store the result even
+         // when it's a miss.
          $found[$key] = $value;
 
          if ($value === self::MISS) {
@@ -71,7 +74,8 @@ class APCu extends Backend {
    }
 
    public function deleteMultiple(array $keys) {
-      // apcu_delete returns an array of errors if you provide an array of keys
+      // The docs leave out the fact that apcu_delete() can take an array of keys,
+      // when you provide an array of keys, it provides an array of errors (if any)
       // so the only successful case is no errors (empty array).
       $ret = apcu_delete($keys);
       return empty($ret);

--- a/library/iFixit/Matryoshka/APCu.php
+++ b/library/iFixit/Matryoshka/APCu.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace iFixit\Matryoshka;
+
+use iFixit\Matryoshka;
+
+class APCu extends Backend {
+   public static function isAvailable() {
+      return function_exists('apcu_enabled') && apcu_enabled();
+   }
+
+   public function set($key, $value, $expiration = 0) {
+      return apcu_store($key, $value, $expiration);
+   }
+
+   public function setMultiple(array $values, $expiration = 0) {
+      return apcu_store($values, null, $expiration);
+   }
+
+   public function add($key, $value, $expiration = 0) {
+      return apcu_add($key, $value, $expiration);
+   }
+
+   public function increment($key, $amount = 1, $expiration = 0) {
+      $value = apcu_inc($key, $amount, $success);
+
+      // Call set() if the key doesn't exist.
+      if ($success) {
+         return $value;
+      } else if ($this->set($key, $amount, $expiration) !== false) {
+         return $amount;
+      } else {
+         return false;
+      }
+   }
+
+   public function decrement($key, $amount = 1, $expiration = 0) {
+      return $this->increment($key, -$amount, $expiration);
+   }
+
+   public function get($key) {
+      $value = apcu_fetch($key, $success);
+
+      return $success ? $value : self::MISS;
+   }
+
+   public function getMultiple(array $keys) {
+      if (empty($keys)) {
+         return [[],[]];
+      }
+
+      // Default to an empty array in case no keys were found.
+      $hits = apcu_fetch(array_keys($keys)) ?: [];
+
+      $found = [];
+      $missed = [];
+      foreach ($keys as $key => $id) {
+         $value = array_key_exists($key, $hits) ? $hits[$key] : self::MISS;
+         $found[$key] = $value;
+
+         if ($value === self::MISS) {
+            $missed[$key] = $id;
+         }
+      }
+
+      return [$found, $missed];
+   }
+
+   public function delete($key) {
+      return apcu_delete($key);
+   }
+
+   public function deleteMultiple(array $keys) {
+      // apcu_delete returns an array of errors if you provide an array of keys
+      // so the only successful case is no errors (empty array).
+      $ret = apcu_delete($keys);
+      return empty($ret);
+   }
+}

--- a/tests/ApcuTest.php
+++ b/tests/ApcuTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once 'AbstractBackendTest.php';
+
+use iFixit\Matryoshka;
+
+class ApcuTest extends AbstractBackendTest {
+   protected function setUp() {
+      if (!Matryoshka\APCu::isAvailable()) {
+         $this->markTestSkipped('Backend not available!');
+      }
+
+      return parent::setUp();
+   }
+
+   protected function getBackend() {
+      return new Matryoshka\APCu();
+   }
+}


### PR DESCRIPTION
The user-land caching part of APC was extracted into an extension
when APC was replaced with Opcache. It's a fast shared-memory store
that is shared by all processes underneath a webserver.

Note: each cli process starts with an empty cache.

Closes #14