### PR TITLE
PHP 7 Memcached: fix calling `Memcached::getMultiple`

### DIFF
--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -28,11 +28,7 @@ class Memcached extends Backend {
          $getMulti = new \ReflectionMethod($memcached, 'getMulti');
          $numArgs = $getMulti->getNumberOfParameters();
 
-         if ($numArgs === 2) {
-            self::$getMultiHasTwoParams = true;
-         } else {
-            self::$getMultiHasTwoParams = false;
-         }
+         self::$getMultiHasTwoParams = $numArgs === 2;
       }
 
       return new KeyShorten(new self($memcached), self::MAX_KEY_LENGTH);

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -8,7 +8,7 @@ class Memcached extends Backend {
    const MAX_KEY_LENGTH = 250;
 
    // Is using instance of Memcache whose `getMulti` only accepts two args.
-   protected static $isPHP7 = null;
+   protected static $getMultiHasTwoParams = null;
 
    private $memcached;
 
@@ -26,14 +26,14 @@ class Memcached extends Backend {
 
       // The PHP 7 version of Memcached has a different API. We can tell which
       // API to use by how many arguments the method takes.
-      if (self::$isPHP7 === null) {
+      if (self::$getMultiHasTwoParams === null) {
          $getMulti = new \ReflectionMethod($memcached, 'getMulti');
          $numArgs = $getMulti->getNumberOfParameters();
 
          if ($numArgs === 2) {
-            self::$isPHP7 = true;
+            self::$getMultiHasTwoParams = true;
          } else {
-            self::$isPHP7 = false;
+            self::$getMultiHasTwoParams = false;
          }
       }
 
@@ -95,7 +95,7 @@ class Memcached extends Backend {
        * the order that they were requested with null indicating a miss which
        * is exactly what is needed for the found array.
        */
-      if (self::$isPHP7 === true) {
+      if (self::$getMultiHasTwoParams === true) {
          // The PHP7 version of Memcached (at the time of this writing) does not
          // accept a `cas_token` param.
          $found = $this->memcached->getMulti(array_keys($keys),

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -22,8 +22,6 @@ class Memcached extends Backend {
     * truncated.
     */
    public static function create(\Memcached $memcached) {
-      $backend = new KeyShorten(new self($memcached), self::MAX_KEY_LENGTH);
-
       // The PHP 7 version of Memcached has a different API. We can tell which
       // API to use by how many arguments the method takes.
       if (self::$getMultiHasTwoParams === null) {
@@ -36,7 +34,6 @@ class Memcached extends Backend {
             self::$getMultiHasTwoParams = false;
          }
       }
-
 
       return new KeyShorten(new self($memcached), self::MAX_KEY_LENGTH);
    }


### PR DESCRIPTION
At the time of this writing, the PHP 7 branch of the memcached client
has a slightly different API than `master`. `getMulti()` takes 2
arguments instead of 3 (it's missing the second `$cas_tokens` argument).

We want Matryoshka to work with both PHP 7 and PHP 5 clients, and this
is the cleanest solution we could think of.

Closes #16