### PR TITLE
Memcached: fix keys with newlines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
 services: memcached
 before_script:

--- a/README.md
+++ b/README.md
@@ -81,11 +81,32 @@ $cache = new Matryoshka\ExpirationChange($backend, $changeFunc);
 $cache->set('key', 'value', 10); // Results in an expiration time of 20.
 ```
 
+### KeyFix
+
+Fixes troublesome keys by shortening longer ones to less than or equal the specified length, and getting rid of any specified, invalid characters.
+It accomplishes this by using `md5` to hash offending keys into an alphanumeric string of uniform length.
+
+```php
+$cache = new Matryoshka\KeyFix(
+   new Matryoshka\Ephemeral(),
+   $maxLength = 50,
+   $invalidChars = " \n"
+);
+
+// Gets converted to: `2552e62135d11e8d4233e2a51868132e`
+$cache->get("long_key_that_needs_to_be_shortened_by_just_a_little_bit");
+
+// Gets converted to: `6c4421388643338490f9c2c895af4fec`
+$cache->get("key with bad chars like spaces");
+```
+
 ### KeyShorten
 
 Ensures that all keys are at most the specified length by shortening longer ones.
 Long keys are shortend by using `md5` on the end of the string
 to ensure long strings with a common prefix don't map to the same key.
+
+Either this _or_ KeyFix should be used, not both. KeyFix handles long keys _and_ bad characters, making this an unnecessary addition.
 
 ```php
 $cache = new Matryoshka\KeyShorten(

--- a/library/iFixit/Matryoshka/KeyFix.php
+++ b/library/iFixit/Matryoshka/KeyFix.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace iFixit\Matryoshka;
+
+use iFixit\Matryoshka;
+
+/**
+ * Shortens long keys and fixes keys with characters that normally aren't
+ * allowed by hashing the key.
+ */
+class KeyFix extends KeyChange {
+   const MD5_STRLEN = 32;
+
+   private $maxLength;
+   private $invalidChars;
+
+   public function __construct(Backend $backend, $maxLength,
+    $invalidChars = " \n") {
+      if ($maxLength < self::MD5_STRLEN) {
+         throw new \InvalidArgumentException(
+          'Max length must be larger than ' . self::MD5_STRLEN);
+      }
+
+      if (!is_string($invalidChars) || $invalidChars === '') {
+         throw new \InvalidArgumentException(
+          'Bad character mask: ' . $invalidChars);
+      }
+
+      parent::__construct($backend);
+
+      $this->maxLength = $maxLength;
+      $this->invalidChars = $invalidChars;
+   }
+
+   public function changeKey($key) {
+      if ($this->safeKey($key)) {
+         return $key;
+      }
+
+      return md5($key);
+   }
+
+   public function changeKeys(array $keys) {
+      foreach ($keys as $key => $value) {
+         if (!$this->safeKey($key)) {
+            $keys[md5($key)] = $value;
+            unset($keys[$key]);
+         }
+      }
+
+      return $keys;
+   }
+
+   /**
+    * Key is safe if it isn't too long, and if it doesn't contain any bad
+    * characters.
+    */
+   private function safeKey($key) {
+      return strlen($key) <= $this->maxLength &&
+       strpbrk($key, $this->invalidChars) === false;
+   }
+}

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -31,7 +31,7 @@ class Memcached extends Backend {
          self::$getMultiHasTwoParams = $numArgs === 2;
       }
 
-      return new KeyShorten(new self($memcached), self::MAX_KEY_LENGTH);
+      return new KeyFix(new self($memcached), self::MAX_KEY_LENGTH);
    }
 
    private function __construct(\Memcached $memcached) {

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -402,7 +402,7 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $validChars = [
          '`', '~', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '_',
          '+', '=', '|', '\\', '[', '{', ']', '}', '<', ',', '>', '.', '?', '/',
-         '☃', "\n", "\r"
+         '☃', "\n", "\r", ' ',
       ];
 
       list($baseKey, $value) = $this->getRandomKeyValue();

--- a/tests/KeyFixTest.php
+++ b/tests/KeyFixTest.php
@@ -1,0 +1,105 @@
+<?php
+
+require_once 'AbstractBackendTest.php';
+
+use iFixit\Matryoshka;
+
+class KeyFixTest extends AbstractBackendTest {
+   protected function getBackend() {
+      return new Matryoshka\KeyFix(new Matryoshka\Ephemeral(), 40);
+   }
+
+   public function testKeyShorten() {
+      $maxLength = 50;
+      $intactKeyLength = $maxLength - Matryoshka\KeyFix::MD5_STRLEN;
+      list($key) = $this->getRandomKeyValue();
+      $longKey = str_repeat($key, 10);
+      $memoryCache = new TestEphemeral();
+      $cache = new Matryoshka\KeyFix($memoryCache, $maxLength);
+
+      $keys = [
+         'short',
+         substr($longKey, 0, $maxLength),
+         substr($longKey, 0, $maxLength + 1),
+         substr($longKey, 0, $maxLength * 10),
+      ];
+
+      foreach ($keys as $key) {
+         $cache->set($key, $key);
+      }
+
+      $cachedValues = $memoryCache->getCache();
+
+      $this->assertCount(count($keys), $cachedValues);
+
+      foreach ($cachedValues as $shortenedKey => $originalKey) {
+         $this->assertLessThanOrEqual($maxLength, strlen($shortenedKey));
+      }
+
+      // Make sure that setMultiple produces the same keys.
+      $memoryCache->clear();
+      $cache->setMultiple(array_combine($keys, $keys));
+      $this->assertSame($cachedValues, $memoryCache->getCache());
+   }
+
+   public function testValidation() {
+      try {
+         new Matryoshka\KeyFix(new TestEphemeral(), 5);
+         $this->fail("Doesn't throw InvalidArgumentException");
+      } catch (InvalidArgumentException $e) {
+         // Do nothing.
+      }
+
+      try {
+         new Matryoshka\KeyFix(new TestEphemeral(), 40, '');
+         $this->fail("Doesn't throw InvalidArgumentException");
+      } catch (InvalidArgumentException $e) {
+         // Do nothing.
+      }
+   }
+
+   public function testNoBadChars() {
+      $memoryCache = new TestEphemeral();
+      $cache = new Matryoshka\KeyFix($memoryCache, 40);
+
+      list($goodKey) = $this->getRandomKeyValue();
+      $cache->set($goodKey, $goodKey);
+
+      foreach ($memoryCache->getCache() as $fixed => $original) {
+         $this->assertSame($fixed, $original);
+      }
+   }
+      
+   public function testDefaultBadChars() {
+      $memoryCache = new TestEphemeral();
+      $cache = new Matryoshka\KeyFix($memoryCache, 40);
+
+      // Empty string and Newline are the default characters this backend fixes.
+      foreach([' ', "\n"] as $badChar) {
+         list($key) = $this->getRandomKeyValue();
+         $badKey = $key . $badChar;
+
+         $cache->set($badKey, $badKey);
+      }
+
+      foreach ($memoryCache->getCache() as $fixed => $original) {
+         $this->assertNotSame($fixed, $original);
+      }
+   }
+
+   public function testCustomBadChars() {
+      $badChar = 'a';
+
+      $memoryCache = new TestEphemeral();
+      $cache = new Matryoshka\KeyFix($memoryCache, 40, $badChar);
+
+      list($key) = $this->getRandomKeyValue();
+      $badKey = $key . $badChar;
+
+      $cache->set($badKey, $badKey);
+
+      foreach ($memoryCache->getCache() as $fixed => $original) {
+         $this->assertNotSame($fixed, $original);
+      }
+   }
+}


### PR DESCRIPTION
Add KeyFix backend to fix keys with invalid characters

When Memcache doesn't like a key, `->set*()` returns `false`. Since this
is (basically) a silent failure, it's tricky to catch.

Danny and I discussed reporting an exception in this case, but then
decided that, if we did find an offender in our code, we'd just hash
they key. So, instead of making a backend that throws exceptions on bad
keys, this is a backend that hashes the bad keys.

This should be used _instead_ of the existing KeyShorten backend, not in
conjunction with it. This backend also handles shortening. The reason
for that is that if we're going to be looping through an array of keys
and mutating them in this backend, we don't want to do it again in
KeyShorten.

Also, KeyShorten would keep the first part of the key:
  BEFORE: long-key-long-key-long-key
  AFTER:  long-key-sd90fus09jf2390fj02f

KeyFix doesn't do that ^

Closes #19