### PR TITLE
Add delete before update backend wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 services: memcached
 before_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-5.1.11; fi;'
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-5.1.11; fi;'
 script:
   - phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+# - hhvm
 services: memcached
 before_script:
   - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-5.1.11; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 services: memcached
 before_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-4.0.10; fi;'
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.6" ] || [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-5.1.11; fi;'
 script:
   - phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
+++ b/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
@@ -12,15 +12,18 @@ use iFixit\Matryoshka;
  */
 class DeleteBeforeUpdate extends BackendWrap {
    public function set($key, $value, $expiration = 0) {
-      if ($this->backend->add($key, $value, $expiration) === false) {
+      $addResponse = $this->backend->add($key, $value, $expiration);
+      if ($addResponse === false) {
          $this->backend->delete($key);
-         $this->backend->set($key, $value, $expiration);
+         return $this->backend->set($key, $value, $expiration);
       }
+      return $addResponse;
    }
 
    public function setMultiple(array $values, $expiration = 0) {
       foreach ($values as $key => $value) {
          $this->set($key, $value, $expiration);
       }
+      return true;
    }
 }

--- a/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
+++ b/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
@@ -12,9 +12,9 @@ use iFixit\Matryoshka;
  */
 class DeleteBeforeUpdate extends BackendWrap {
    public function set($key, $value, $expiration = 0) {
-      if ($this->backend->add($key, $value) === false) {
+      if ($this->backend->add($key, $value, $expiration) === false) {
          $this->backend->delete($key);
-         $this->backend->set($key, $value);
+         $this->backend->set($key, $value, $expiration);
       }
    }
 

--- a/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
+++ b/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace iFixit\Matryoshka;
+
+use iFixit\Matryoshka;
+
+/**
+ * Ensures that a delete is issued before trying to update an existing key.
+ *
+ * This layer is useful for working with mcrouter. mcrouter provides a reliable
+ * delete stream, but can't guarantee updates are recorded.
+ */
+class DeleteBeforeUpdate extends BackendWrap {
+   public function set($key, $value, $expiration = 0) {
+      if ($this->backend->add($key, $value) === false) {
+         $this->backend->delete($key);
+         $this->backend->add($key, $valaue);
+      }
+   }
+
+   public function setMultiple(array $values, $expiration = 0) {
+      foreach ($values as $key => $value) {
+         $this->set($key, $value, $expiration);
+      }
+   }
+}

--- a/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
+++ b/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
@@ -14,7 +14,7 @@ class DeleteBeforeUpdate extends BackendWrap {
    public function set($key, $value, $expiration = 0) {
       if ($this->backend->add($key, $value) === false) {
          $this->backend->delete($key);
-         $this->backend->add($key, $valaue);
+         $this->backend->set($key, $valaue);
       }
    }
 

--- a/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
+++ b/library/iFixit/Matryoshka/DeleteBeforeUpdate.php
@@ -14,7 +14,7 @@ class DeleteBeforeUpdate extends BackendWrap {
    public function set($key, $value, $expiration = 0) {
       if ($this->backend->add($key, $value) === false) {
          $this->backend->delete($key);
-         $this->backend->set($key, $valaue);
+         $this->backend->set($key, $value);
       }
    }
 

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -9,7 +9,7 @@ use iFixit\Matryoshka;
 
 Matryoshka::autoload();
 
-abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
+abstract class AbstractBackendTest extends \PHPUnit\Framework\TestCase {
    protected abstract function getBackend();
 
    /**

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -3,6 +3,7 @@
 // Be very strict about errors when testing.
 error_reporting(E_ALL);
 
+require_once 'PHPUnit/Autoload.php';
 require_once __DIR__ . '/../library/iFixit/Matryoshka.php';
 
 use iFixit\Matryoshka;

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -3,7 +3,6 @@
 // Be very strict about errors when testing.
 error_reporting(E_ALL);
 
-require_once 'PHPUnit/Autoload.php';
 require_once __DIR__ . '/../library/iFixit/Matryoshka.php';
 
 use iFixit\Matryoshka;

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -6,10 +6,13 @@ error_reporting(E_ALL);
 require_once __DIR__ . '/../library/iFixit/Matryoshka.php';
 
 use iFixit\Matryoshka;
+if (!class_exists("PHPUnit_Framework_TestCase", false)) {
+   abstract class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
+}
 
 Matryoshka::autoload();
 
-abstract class AbstractBackendTest extends \PHPUnit\Framework\TestCase {
+abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
    protected abstract function getBackend();
 
    /**


### PR DESCRIPTION
Does an add delete add on each of the keys in the case that someone is
trying to update an existing key. When switching to mcrouter, we only
have a reliable delete stream, we don't have a way to see if any other
requests to a memcache machine have failed, so this wrapper will ensure
that when updating something, we're always doing a delete and add
instead of updating a key.