### PR TITLE
Memcached: treat false like any other value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.3
 # - hhvm
 services: memcached
+install: composer install
 script:
-  - phpunit tests
+  - vendor/bin/phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 # - hhvm
 services: memcached
-before_script:
-  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.5" ] || [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then phpenv config-add .travisphpconfig.ini ; echo no | pecl install -f apcu-5.1.11; fi;'
 script:
   - phpunit tests
   - php benchmarks/MatryoshkaBenchmark.php

--- a/.travisphpconfig.ini
+++ b/.travisphpconfig.ini
@@ -1,4 +1,0 @@
-extension="memcache.so"
-extension="memcached.so"
-extension="apcu.so"
-apc.enable_cli=1

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
       }
    ],
    "require": {
-      "php": ">=5.4.0"
+      "php": ">=5.4.0",
+      "phpunit/phpunit": "5.7.27"
    },
    "autoload": {
       "psr-0": {"iFixit": "library/"}

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -68,7 +68,11 @@ class Memcached extends Backend {
    public function get($key) {
       $value = $this->memcached->get($key);
 
-      return $value === false ? self::MISS : $value;
+      if ($this->memcached->getResultCode() === \Memcached::RES_NOTFOUND) {
+         return self::MISS;
+      }
+
+      return $value;
    }
 
    public function getMultiple(array $keys) {

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -6,7 +6,7 @@ error_reporting(E_ALL);
 require_once __DIR__ . '/../library/iFixit/Matryoshka.php';
 
 use iFixit\Matryoshka;
-if (!class_exists("PHPUnit_Framework_TestCase", false)) {
+if (!class_exists("PHPUnit_Framework_TestCase")) {
    abstract class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase {}
 }
 

--- a/tests/MemcachedTest.php
+++ b/tests/MemcachedTest.php
@@ -31,4 +31,13 @@ class MemcachedTest extends AbstractBackendTest {
 
       $this->assertNull($backend->get($key));
    }
+
+   public function testFalse() {
+      $backend = $this->getBackend();
+      list($key1) = $this->getRandomKeyValue();
+
+      $this->assertNull($backend->get($key1));
+      $this->assertTrue($backend->set($key1, false));
+      $this->assertFalse($backend->get($key1));
+   }
 }


### PR DESCRIPTION
null is our sentinel value for misses, but there's no reason why `false`
needs to also be considered a miss.