### PR TITLE
Bugfix: Drop the string type on $key

### DIFF
--- a/library/iFixit/Matryoshka/KeyChange.php
+++ b/library/iFixit/Matryoshka/KeyChange.php
@@ -5,7 +5,7 @@ namespace iFixit\Matryoshka;
 use iFixit\Matryoshka;
 
 abstract class KeyChange extends BackendWrap {
-   public abstract function changeKey(string $key);
+   public abstract function changeKey($key);
 
    /**
     * Convert many keys at once.


### PR DESCRIPTION
Wat? Psalm inferred that type, and never complained that any of the
implementations of this method had bad signatures? That's _weird_.

Dropping the string type here makes this definition compatible with all
of the implementations.

The bug was introduced automagically here:
https://github.com/iFixit/Matryoshka/pull/24/commits/b97ba42293a93451aecdbc43b68d89ae18cb2028

cr_req 1
qa_req 0

CC @k0rvusk0r4x @jarstelfox 