### PR TITLE
Run Tests on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - 7.3
+  - 7.4
 services: memcached
 install: composer install
 before_script: echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
We're running 7.4 now. Lets run tests against that runtime as well.

cr_req 1
qa_req 0

CC @iFixit/devops 