### PR TITLE
PHP 8: test for compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+  - 7.3
   - 7.4
   - 8.0
 services: memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-  - 7.3
   - 7.4
+  - 8.0
 services: memcached
 install: composer install
 before_script: echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 8.0
 services: memcached
 install: composer install
-before_script: echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+before_script: yes '' | pecl install -f memcached
 script:
   - ./vendor/bin/psalm
   - vendor/bin/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
       }
    ],
    "require": {
-      "php": ">=7.4.0"
+      "php": "^7.3 || ^8.0"
    },
    "autoload": {
       "psr-0": {"iFixit": "library/"}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
    },
    "require-dev": {
       "phpunit/phpunit": "^8.5",
-      "vimeo/psalm": "^3.8"
+      "vimeo/psalm": "^4"
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
       }
    ],
    "require": {
-      "php": ">=7.3.0"
+      "php": ">=7.4.0"
    },
    "autoload": {
       "psr-0": {"iFixit": "library/"}

--- a/library/iFixit/Matryoshka/APCu.php
+++ b/library/iFixit/Matryoshka/APCu.php
@@ -13,6 +13,12 @@ class APCu extends Backend {
       return apcu_store($key, $value, $expiration);
    }
 
+   /**
+    * TODO: the other backends' setMultiple() returns a bool, we should fix the way we're
+    * handling this for consistency. See: https://github.com/iFixit/Matryoshka/issues/30
+    *
+    * @return array Returns array of keys that had errors
+    */
    public function setMultiple(array $values, $expiration = 0) {
       return apcu_store($values, null, $expiration);
    }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
+<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
   <file src="library/iFixit/Matryoshka/APCu.php">
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>array</code>
     </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="library/iFixit/Matryoshka/Ephemeral.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(int)$amount</code>
+    </RedundantCastGivenDocblockType>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
+  <file src="library/iFixit/Matryoshka/APCu.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>array</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -35,7 +35,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="library/iFixit" />


### PR DESCRIPTION
This also adds a `psalm` baseline, for some issues uncovered in the process of running tests on PHP 8

UPDATE: also had to update Psalm to fix this failing 7.3 build: https://github.com/iFixit/Matryoshka/runs/1964233468

cr_req 1
qa_req 0