### PR TITLE
Psalm: upgrade to 4.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
    },
    "require-dev": {
       "phpunit/phpunit": "^8.5",
-      "vimeo/psalm": "^3.8"
+      "vimeo/psalm": "^4"
    }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.18.2@19aa905f7c3c7350569999a93c40ae91ae4e1626">
+<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
   <file src="library/iFixit/Matryoshka/APCu.php">
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>array</code>
     </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="library/iFixit/Matryoshka/Ephemeral.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(int)$amount</code>
+    </RedundantCastGivenDocblockType>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -35,7 +35,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />


### PR DESCRIPTION
This removes a deprecated rule from the config and baselines one new,
minor issue Psalm turned up.

cr_req 1
qa_req 0
