### PR TITLE
Memcached: Throw on too large of value

### DIFF
--- a/library/iFixit/Matryoshka/Exceptions/ValueTooLargeException.php
+++ b/library/iFixit/Matryoshka/Exceptions/ValueTooLargeException.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace iFixit\Matryoshka\Exceptions;
-
-class ValueTooLargeException extends \Exception {}

--- a/library/iFixit/Matryoshka/Exceptions/ValueTooLargeException.php
+++ b/library/iFixit/Matryoshka/Exceptions/ValueTooLargeException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace iFixit\Matryoshka\Exceptions;
+
+class ValueTooLargeException extends \Exception {}

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -37,10 +37,13 @@ class Memcached extends Backend {
 
    public function set($key, $value, $expiration = 0) {
       $setValue = $this->memcached->set($key, $value, $expiration);
+      $resultCode = $this->memcached->getResultCode();
 
-      if ($this->memcached->getResultCode() === \Memcached::RES_E2BIG) {
-         throw new ValueTooLargeException();
+      if ($resultCode !== \Memcached::RES_SUCCESS) {
+         $errorMessage = $this->memcached->getResultMessage();
+         throw new \MemcachedException($errorMessage, $resultCode);
       }
+
       return $setValue;
    }
 

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -36,7 +36,7 @@ class Memcached extends Backend {
    }
 
    public function set($key, $value, $expiration = 0) {
-      if ($this->memcached->set($key, $value, $expiration) {
+      if ($this->memcached->set($key, $value, $expiration)) {
          return true;
       }
       

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -36,7 +36,12 @@ class Memcached extends Backend {
    }
 
    public function set($key, $value, $expiration = 0) {
-      return $this->memcached->set($key, $value, $expiration);
+      $setValue = $this->memcached->set($key, $value, $expiration);
+
+      if ($this->memcached->getResultCode() === \Memcached::RES_E2BIG) {
+         throw new ValueTooLargeException();
+      }
+      return $setValue;
    }
 
    public function setMultiple(array $values, $expiration = 0) {

--- a/library/iFixit/Matryoshka/Memcached.php
+++ b/library/iFixit/Matryoshka/Memcached.php
@@ -36,15 +36,14 @@ class Memcached extends Backend {
    }
 
    public function set($key, $value, $expiration = 0) {
-      $setValue = $this->memcached->set($key, $value, $expiration);
-      $resultCode = $this->memcached->getResultCode();
-
-      if ($resultCode !== \Memcached::RES_SUCCESS) {
-         $errorMessage = $this->memcached->getResultMessage();
-         throw new \MemcachedException($errorMessage, $resultCode);
+      if ($this->memcached->set($key, $value, $expiration) {
+         return true;
       }
-
-      return $setValue;
+      
+      // The set failed so throw a detailed exception.
+      $resultCode = $this->memcached->getResultCode();
+      $errorMessage = $this->memcached->getResultMessage();
+      throw new \MemcachedException($errorMessage, $resultCode);
    }
 
    public function setMultiple(array $values, $expiration = 0) {

--- a/tests/MemcachedTest.php
+++ b/tests/MemcachedTest.php
@@ -58,4 +58,23 @@ class MemcachedTest extends AbstractBackendTest {
       $this->assertTrue($backend->set($key1, false));
       $this->assertFalse($backend->get($key1));
    }
+
+   public function testSetValueTooBig() {
+      $this->expectException(MemcachedException::class);
+      $this->expectExceptionCode(\Memcached::RES_E2BIG);
+
+      $badMemcached = new class extends \Memcached {
+         public function set($key, $value = null, $expiration = null) {
+            return false;
+         }
+
+         public function getResultCode() {
+            return \Memcached::RES_E2BIG;
+         }
+      };
+
+      $backend = Matryoshka\Memcached::create($badMemcached);
+      [$key, $value] = $this->getRandomKeyValue();
+      $backend->set($key, $value);
+   }
 }


### PR DESCRIPTION
When trying to set a value that is too large, memcached just return false.
Instead, throw an exception every time set fails.

