### PR TITLE
Backend->getAndSet: Add better typing

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install libmemcached
+      run: sudo apt-get install -y libmemcached-dev
+
     - name: Install PHP with extensions
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,8 @@ jobs:
         php-version: ${{ matrix.php-version }}
         extensions: memcached-3.2.0
         coverage: none
+          env:
+        fail-fast: true
 
     - name: Setup Memcached server
       uses: niden/actions-memcached@v7

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,7 +32,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: memcached
+        extensions: memcached-3.2.0
         coverage: none
 
     - name: Setup Memcached server

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,7 +34,7 @@ jobs:
         php-version: ${{ matrix.php-version }}
         extensions: memcached-3.2.0
         coverage: none
-          env:
+      env:
         fail-fast: true
 
     - name: Setup Memcached server

--- a/library/iFixit/Matryoshka/Backend.php
+++ b/library/iFixit/Matryoshka/Backend.php
@@ -123,9 +123,11 @@ abstract class Backend {
     * $callback returns Backend::NULL, the corresponding set() call won't
     * happen.
     *
-    * @param mixed $reset If truthy, always call the callback to reset the cache.
+    * @template T
+    * @param callable():T $callback A callback to generate the cached value
+    * @param bool $reset If truthy, always call the callback to reset the cache.
     *
-    * @return mixed the value
+    * @return T the value from the cache or the callback
     */
    public function getAndSet($key, callable $callback, int $expiration = 0,
     $reset = false) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/tests/MemcachedTest.php
+++ b/tests/MemcachedTest.php
@@ -35,7 +35,7 @@ class MemcachedTest extends AbstractBackendTest {
     public function testFailureException() {
       [$key] = $this->getRandomKeyValue();
       $badMemcached = new class extends \Memcached {
-         public function get(string $key, callable $cache_cb = null, int $get_flags = 0): mixed {
+         public function get($key, $cache_cb = null, $get_flags = 0): mixed {
             return false;
          }
 
@@ -63,7 +63,7 @@ class MemcachedTest extends AbstractBackendTest {
       $this->expectExceptionCode(\Memcached::RES_E2BIG);
 
       $badMemcached = new class extends \Memcached {
-         public function set($key, mixed $value, int $expiration = null): bool {
+         public function set($key, $value, $expiration = null): bool {
             return false;
          }
 


### PR DESCRIPTION
This should allow Psalm to come up with a pretty good idea of the type returned from a `getAndSet`.

## QA notes:
qa_req 0

This is 100% a comment change.

Connects ifixit/ifixit#41492
