### PR TITLE
Scope: make key more random

### DIFF
--- a/library/iFixit/Matryoshka/Scope.php
+++ b/library/iFixit/Matryoshka/Scope.php
@@ -25,7 +25,7 @@ class Scope extends Prefix {
       if ($this->scopePrefix === null || $reset) {
          $scopeValue = $this->backend->getAndSet($this->getScopeKey(),
           function() {
-            return substr(md5(microtime() . $this->scopeName), 0, 8);
+            return substr(md5(microtime() . $this->scopeName), 0, 16);
          }, 0, $reset);
 
          $this->scopePrefix = "{$scopeValue}-";


### PR DESCRIPTION
I think it is actually possible there's cache collisions happening here. The `Scope` key was only an 8 character hex value.

If the number of things we're caching under one cache scope is in the hundreds of thousands or millions I think there could be multiple collisions:
https://en.wikipedia.org/wiki/Birthday_problem#Probability_table

qa_req 0 -- Nothing really to QA here.
