### PR TITLE
Scope: Fix TOCTOU race in prefix initialization

### DIFF
--- a/library/iFixit/Matryoshka/Backend.php
+++ b/library/iFixit/Matryoshka/Backend.php
@@ -137,7 +137,11 @@ abstract class Backend {
          $value = $callback();
 
          if ($value !== self::MISS) {
-            $this->set($key, $value, $expiration);
+            if ($reset) {
+               $this->set($key, $value, $expiration);
+            } else if (!$this->add($key, $value, $expiration)) {
+               $value = $this->get($key) ?? $value;
+            }
          }
       }
 

--- a/library/iFixit/Matryoshka/Scope.php
+++ b/library/iFixit/Matryoshka/Scope.php
@@ -23,35 +23,26 @@ class Scope extends Prefix {
 
    public function getScopePrefix(bool $reset = false, bool $generateOnMiss = true) {
       if ($this->scopePrefix === null || $reset) {
-         $key = $this->getScopeKey();
-
-         if ($reset) {
-            // Intentional overwrite (used by deleteScope())
-            $scopeValue = $this->generateScopeValue();
-            $this->backend->set($key, $scopeValue);
-         } else {
-            $scopeValue = $this->backend->get($key);
+         if (!$reset && !$generateOnMiss) {
+            $scopeValue = $this->backend->get($this->getScopeKey());
             if ($scopeValue === self::MISS) {
-               if (!$generateOnMiss) {
-                  return self::MISS;
-               }
-               $scopeValue = $this->generateScopeValue();
-               // Use add() for first-writer-wins atomicity.
-               // If another process already wrote the key, use their value.
-               if (!$this->backend->add($key, $scopeValue)) {
-                  $scopeValue = $this->backend->get($key) ?? $scopeValue;
-               }
+               return self::MISS;
             }
+         } else {
+            $scopeValue = $this->backend->getAndSet(
+               $this->getScopeKey(),
+               function() {
+                  return substr(md5(microtime() . $this->scopeName), 0, 16);
+               },
+               0,
+               $reset
+            );
          }
 
          $this->scopePrefix = "{$scopeValue}-";
       }
 
       return $this->scopePrefix;
-   }
-
-   private function generateScopeValue(): string {
-      return substr(md5(microtime() . $this->scopeName), 0, 16);
    }
 
    public function getScopeName() {

--- a/library/iFixit/Matryoshka/Scope.php
+++ b/library/iFixit/Matryoshka/Scope.php
@@ -23,19 +23,35 @@ class Scope extends Prefix {
 
    public function getScopePrefix(bool $reset = false, bool $generateOnMiss = true) {
       if ($this->scopePrefix === null || $reset) {
-         $scopeValue = $reset ? self::MISS : $this->backend->get($this->getScopeKey());
-         if ($scopeValue === self::MISS) {
-            if ($generateOnMiss) {
-               $scopeValue = substr(md5(microtime() . $this->scopeName), 0, 16);
-               $this->backend->set($this->getScopeKey(), $scopeValue);
-            } else {
-               return self::MISS;
+         $key = $this->getScopeKey();
+
+         if ($reset) {
+            // Intentional overwrite (used by deleteScope())
+            $scopeValue = $this->generateScopeValue();
+            $this->backend->set($key, $scopeValue);
+         } else {
+            $scopeValue = $this->backend->get($key);
+            if ($scopeValue === self::MISS) {
+               if (!$generateOnMiss) {
+                  return self::MISS;
+               }
+               $scopeValue = $this->generateScopeValue();
+               // Use add() for first-writer-wins atomicity.
+               // If another process already wrote the key, use their value.
+               if (!$this->backend->add($key, $scopeValue)) {
+                  $scopeValue = $this->backend->get($key);
+               }
             }
          }
+
          $this->scopePrefix = "{$scopeValue}-";
       }
 
       return $this->scopePrefix;
+   }
+
+   private function generateScopeValue(): string {
+      return substr(md5(microtime() . $this->scopeName), 0, 16);
    }
 
    public function getScopeName() {

--- a/library/iFixit/Matryoshka/Scope.php
+++ b/library/iFixit/Matryoshka/Scope.php
@@ -39,7 +39,7 @@ class Scope extends Prefix {
                // Use add() for first-writer-wins atomicity.
                // If another process already wrote the key, use their value.
                if (!$this->backend->add($key, $scopeValue)) {
-                  $scopeValue = $this->backend->get($key);
+                  $scopeValue = $this->backend->get($key) ?? $scopeValue;
                }
             }
          }

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -285,13 +285,16 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
    }
 
    public function testGetAndSetReturnsComputedValue() {
-      $enable = new Matryoshka\Enable($this->getBackend());
-      $enable->writesEnabled = false;
+      $backend = new class extends Matryoshka\Ephemeral {
+         public function add($key, $value, $expiration = 0) {
+            return false;
+         }
+      };
 
       [$key] = $this->getRandomKeyValue();
       $computedValue = 'computed';
 
-      $result = $enable->getAndSet($key, function() use ($computedValue) {
+      $result = $backend->getAndSet($key, function() use ($computedValue) {
          return $computedValue;
       });
 

--- a/tests/AbstractBackendTest.php
+++ b/tests/AbstractBackendTest.php
@@ -284,6 +284,39 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
       $this->assertSame($value, $backend->get($key));
    }
 
+   public function testGetAndSetReturnsComputedValue() {
+      $enable = new Matryoshka\Enable($this->getBackend());
+      $enable->writesEnabled = false;
+
+      [$key] = $this->getRandomKeyValue();
+      $computedValue = 'computed';
+
+      $result = $enable->getAndSet($key, function() use ($computedValue) {
+         return $computedValue;
+      });
+
+      $this->assertSame($computedValue, $result);
+   }
+
+   public function testGetAndSetConcurrentInitUsesFirstWriter() {
+      $racing = new RacingBackend($this->getBackend());
+      [$key] = $this->getRandomKeyValue();
+
+      $firstWriterValue = 'first-writer';
+      $secondWriterValue = 'second-writer';
+
+      $racing->afterNextGet(function($key) use ($racing, $firstWriterValue) {
+         $racing->set($key, $firstWriterValue);
+      });
+
+      $result = $racing->getAndSet($key, function() use ($secondWriterValue) {
+         return $secondWriterValue;
+      });
+
+      $this->assertSame($firstWriterValue, $result);
+      $this->assertSame($firstWriterValue, $racing->get($key));
+   }
+
    public function testgetAndSetMultiple() {
       $backend = $this->getBackend();
       list($key1, $value1, $id1) = $this->getRandomKeyValueId();
@@ -487,6 +520,27 @@ abstract class AbstractBackendTest extends PHPUnit_Framework_TestCase {
     */
    protected function isCharExemptFromKeyEquivalence($char) {
       return false;
+   }
+}
+
+/**
+ * Simulates a concurrent writer on a shared backend by injecting
+ * behavior between get() returning and the caller acting on the result.
+ */
+class RacingBackend extends Matryoshka\BackendWrap {
+   private $afterNextGet = null;
+
+   public function afterNextGet(callable $fn) {
+      $this->afterNextGet = $fn;
+   }
+
+   public function get($key) {
+      $result = $this->backend->get($key);
+      if ($fn = $this->afterNextGet) {
+         $this->afterNextGet = null;
+         $fn($key);
+      }
+      return $result;
    }
 }
 

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -4,28 +4,6 @@ require_once 'AbstractBackendTest.php';
 
 use iFixit\Matryoshka;
 
-/**
- * Simulates a concurrent writer on a shared backend (APCu, Memcached)
- * by injecting behavior between get() returning and the caller acting
- * on the result.
- */
-class RacingBackend extends Matryoshka\BackendWrap {
-   private $afterNextGet = null;
-
-   public function afterNextGet(callable $fn) {
-      $this->afterNextGet = $fn;
-   }
-
-   public function get($key) {
-      $result = $this->backend->get($key);
-      if ($fn = $this->afterNextGet) {
-         $this->afterNextGet = null;
-         $fn($key);
-      }
-      return $result;
-   }
-}
-
 class ScopeTest extends AbstractBackendTest {
    protected function getBackend() {
       return new Matryoshka\Scope(new Matryoshka\Ephemeral(), 'scope');

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -152,4 +152,22 @@ class ScopeTest extends AbstractBackendTest {
 
       $this->assertSame('competitor-data', $scope->get('user-data'));
    }
+
+   /**
+    * If add() fails and the re-fetch also misses (e.g. the backend lost
+    * the key between add and get), the generated prefix is still used.
+    */
+   public function testScopePrefixNotEmpty() {
+      $backend = new class extends Matryoshka\Ephemeral {
+         public function add($key, $value, $expiration = 0) {
+            return false;
+         }
+      };
+      $scope = new Matryoshka\Scope($backend, 'test-scope');
+
+      $prefix = $scope->getScopePrefix();
+
+      $this->assertNotSame('-', $prefix);
+      $this->assertStringEndsWith('-', $prefix);
+   }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -4,6 +4,28 @@ require_once 'AbstractBackendTest.php';
 
 use iFixit\Matryoshka;
 
+/**
+ * Simulates a concurrent writer on a shared backend (APCu, Memcached)
+ * by injecting behavior between get() returning and the caller acting
+ * on the result.
+ */
+class RacingBackend extends Matryoshka\BackendWrap {
+   private $afterNextGet = null;
+
+   public function afterNextGet(callable $fn) {
+      $this->afterNextGet = $fn;
+   }
+
+   public function get($key) {
+      $result = $this->backend->get($key);
+      if ($fn = $this->afterNextGet) {
+         $this->afterNextGet = null;
+         $fn($key);
+      }
+      return $result;
+   }
+}
+
 class ScopeTest extends AbstractBackendTest {
    protected function getBackend() {
       return new Matryoshka\Scope(new Matryoshka\Ephemeral(), 'scope');
@@ -97,5 +119,59 @@ class ScopeTest extends AbstractBackendTest {
       [$key] = $this->getRandomKeyValue();
 
       $this->assertEquals($scopedCache->getScopePrefix() . $key, $scopedCache->getAbsoluteKey($key));
+   }
+
+   public function testConcurrentPrefixInitUsesFirstWriter() {
+      $racing = new RacingBackend(new Matryoshka\Ephemeral());
+      $scope = new Matryoshka\Scope($racing, 'test-scope');
+
+      $competitorPrefix = 'competitor-won';
+
+      $racing->afterNextGet(function($key) use ($racing, $competitorPrefix) {
+         $racing->set($key, $competitorPrefix);
+      });
+
+      $prefix = $scope->getScopePrefix();
+
+      $this->assertSame("{$competitorPrefix}-", $prefix);
+      $this->assertSame($competitorPrefix, $racing->get('scope-test-scope'));
+   }
+
+   public function testScopePrefixInitializationNoRace() {
+      $inner = new Matryoshka\Ephemeral();
+      $scope = new Matryoshka\Scope($inner, 'test-scope');
+
+      $prefix = $scope->getScopePrefix();
+
+      $this->assertNotEmpty($prefix);
+      $this->assertStringEndsWith('-', $prefix);
+      $this->assertSame($prefix, $scope->getScopePrefix());
+   }
+
+   public function testDeleteScopeOverwritesIntentionally() {
+      $inner = new Matryoshka\Ephemeral();
+      $scope = new Matryoshka\Scope($inner, 'test-scope');
+
+      $originalPrefix = $scope->getScopePrefix();
+      $scope->deleteScope();
+      $newPrefix = $scope->getScopePrefix();
+
+      $this->assertNotSame($originalPrefix, $newPrefix);
+   }
+
+   public function testConcurrentPrefixInitPreservesFirstWriterData() {
+      $racing = new RacingBackend(new Matryoshka\Ephemeral());
+      $scope = new Matryoshka\Scope($racing, 'test-scope');
+
+      $competitorPrefix = 'competitor-won';
+
+      $racing->afterNextGet(function($key) use ($racing, $competitorPrefix) {
+         $racing->set($key, $competitorPrefix);
+         $racing->set("{$competitorPrefix}-user-data", 'competitor-data');
+      });
+
+      $scope->getScopePrefix();
+
+      $this->assertSame('competitor-data', $scope->get('user-data'));
    }
 }


### PR DESCRIPTION
Backend::getAndSet() has Time-of-Check-Time-of-Use (TOCTOU) race conditions. It performs non-atomic `get()` then `set()`, so concurrent callers that both observe a miss will each compute and write different values. The last writer wins, silently orphaning data written by earlier callers under the first value.

Add a regression test documenting the race conditions, and the new expected behavior to handle concurrent writes.

We can use `add()` instead of `set()` when setting backend values so the first writer wins. If `add()` fails, re-`get()` to pick up the winner's value. The `$reset` path (deleteScope) still uses `set()` for intentional overwrites.

Note this addresses the race for both the Scope prefix, as well as `getAndSet`.

Ref:
- https://github.com/iFixit/Matryoshka/issues/42

CC @sctice-ifixit @danielbeardsley 