### PR TITLE
Scope: Delete key when deleting scope

### DIFF
--- a/library/iFixit/Matryoshka/Scope.php
+++ b/library/iFixit/Matryoshka/Scope.php
@@ -21,9 +21,9 @@ class Scope extends Prefix {
       return $this->scopePrefix ?: $this->getScopePrefix();
    }
 
-   public function getScopePrefix(bool $reset = false, bool $generateOnMiss = true) {
-      if ($this->scopePrefix === null || $reset) {
-         $scopeValue = $reset ? self::MISS : $this->backend->get($this->getScopeKey());
+   public function getScopePrefix(bool $generateOnMiss = true) {
+      if ($this->scopePrefix === null) {
+         $scopeValue = $this->backend->get($this->getScopeKey());
          if ($scopeValue === self::MISS) {
             if ($generateOnMiss) {
                $scopeValue = substr(md5(microtime() . $this->scopeName), 0, 16);

--- a/library/iFixit/Matryoshka/Scope.php
+++ b/library/iFixit/Matryoshka/Scope.php
@@ -9,7 +9,7 @@ class Scope extends Prefix {
    private $scopePrefix;
 
    public function __construct(Backend $backend, $scopeName) {
-      // The prefix we pass along to the Prefix() constructor is never used, so 
+      // The prefix we pass along to the Prefix() constructor is never used, so
       // it doesn't matter.
       parent::__construct($backend, /* $prefix = */ null);
 
@@ -47,10 +47,12 @@ class Scope extends Prefix {
     * this scope.
     */
    public function deleteScope(): bool {
-      // Delete the scope by setting a new value for it.
-      $prefix = $this->getScopePrefix($reset = true);
+      // Explicitly delete the scope key from the backend to ensure that it is
+      // removed.
+      $this->backend->delete($this->getScopeKey());
+      $this->scopePrefix = null;
 
-      return $prefix !== self::MISS;
+      return true;
    }
 
    private function getScopeKey() {


### PR DESCRIPTION
Previously, to "delete" a scope, we immediately generated a new value and set() it overtop of the previous one.

1. This isn't really needed. Sometimes we deleteScope() and don't immediately access it, so doing it eagerly was un-needed
2. When using McRouter, delete() is guaranteed to be propagated while set() has a less strong guarantee

Yes, this means that in some cases (hard to tell how common) delete is followed by a set() of the scope key shortly afterward and this change adds a delete where one wasn't present before.

However, I think this is outweighed by point 1 above and point 2 shows that this change is important.

The code as it was meant that in our odd case with a bifurcated cache, we had to issue a delete() with every set() because deleteScope() only did a set(). There is a bunch of nuance here (see
https://github.com/iFixit/ifixit/pull/62768).

cr_req 2 -- I want more people to be happy with this change
qa_req 0 -- CI is enough.

CC @sterlinghirsh @jarstelfox @djmetzle 